### PR TITLE
Add override for new method in Granularity class

### DIFF
--- a/arbitrary-granularity/src/main/java/org/apache/druid/java/util/common/granularity/ArbitraryGranularity.java
+++ b/arbitrary-granularity/src/main/java/org/apache/druid/java/util/common/granularity/ArbitraryGranularity.java
@@ -106,6 +106,15 @@ public class ArbitraryGranularity extends Granularity
 
   // Used only for Segments. Not for Queries
   @Override
+  public boolean isAligned(Interval interval)
+  {
+    throw new UnsupportedOperationException(
+      "This method should not be invoked for this granularity type"
+    );
+  }
+
+  // Used only for Segments. Not for Queries
+  @Override
   public DateTimeFormatter getFormatter(Formatter type)
   {
     throw new UnsupportedOperationException(


### PR DESCRIPTION
https://github.com/apache/incubator-druid/pull/7547

This PR introduced a new method in the Granularity Class. It appears to me that it is for segments only as it is related to compaction. Therefore, I went ahead and applied the existing pattern for segment only methods (throwing UnsupportedOperationException). After this change locally, it compiled fine with Druid 16.